### PR TITLE
Allow loading scripts which generate blueprints.

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -438,6 +438,9 @@ function createNewBlueprintWindow(gui, blueprintName)
 
   flow = frame.add({type="flow", name="blueprintNewFixFlow", direction="horizontal"})
   flow.add({type="checkbox", name="fixPositions", caption="fix positions", state = true})
+  
+  flow = frame.add({type="flow", name="blueprintNewUnsafeFlow", direction="horizontal"})
+  flow.add({type="checkbox", name="unsafe", caption="allow scripts (unsafe!)", state = false})
 
   flow = frame.add({type="flow", name="blueprintNewButtonFlow", direction="horizontal"})
   flow.add({type="button", name="blueprintNewCancel", caption={"btn-cancel"}})
@@ -684,7 +687,12 @@ local function on_gui_click(event)
       else
         -- read pasted string
         if string.starts_with(importString, "do local") then
-          blueprintData = BlueprintString.load(importString)
+          local unsafe = event.element.parent.parent.blueprintNewUnsafeFlow.unsafe.state
+          if unsafe then 
+            blueprintData = loadstring(importString)()
+          else
+            blueprintData = BlueprintString.load(importString)
+          end
           if blueprintData then
             blueprintData = deserializeBlueprintData(blueprintData)
           end


### PR DESCRIPTION
This tiny patch allows running scripts directly which return blueprint data, instead of 'sanitizing' them through BlueprintString/Serpent. As this is less safe, it must be enabled every time it is used, and resets to disabled after use.

This allows scripts which generate blueprints from smaller bits of data to be used directly. My specific use case is a script which generates a ROM blueprint from the ROM's data, to simplify loading programs into a large combinator CPU.
